### PR TITLE
Update Readme: must sync db before running seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ You will need the following things properly installed on your computer.
 
 ## Setup For Development Environment
 
-* Create a postgres user with the name 'troublemaker' and a database with the same name, as mentioned in `config/config.js`.
+* `yarn run sq db:create` To create a postgres user with the name 'troublemaker' and a database with the same name, as mentioned in `config/config.js`.     
+* run `node index.js` ( for sync db ) and open new tab to run bellow command
 * `yarn run sq db:seed:all` to run all the seed files. You now have a dummy user in your database
 
 ## Further Reading / Useful Links


### PR DESCRIPTION
Fixes #14 
Changes: Added instructions for sync db before running seed
Screenshot:
![1](https://user-images.githubusercontent.com/49281840/57831544-0f4cb180-77d3-11e9-9345-b7e28303cf53.png)

